### PR TITLE
#17: add User-Agent header to Overpass API requests

### DIFF
--- a/src/service/overpass-client.service.ts
+++ b/src/service/overpass-client.service.ts
@@ -1,21 +1,55 @@
 import { FeatureCollection, GeometryObject } from 'geojson';
 import { Injectable } from '@nestjs/common';
+import * as https from 'https';
+import * as querystring from 'querystring';
 
-const QueryOverpass = require('query-overpass');
+const osmtogeojson = require('osmtogeojson');
+const xmldom = require('xmldom');
 
 @Injectable()
 export class OverpassClientService {
   async query(query: string): Promise<FeatureCollection<GeometryObject>> {
     console.log('Overpass query: ' + query);
-    return new Promise<FeatureCollection<GeometryObject>>((resolve, reject) => {
-      QueryOverpass(query, function (err: any, geojson: FeatureCollection<GeometryObject>) {
-        if (!err) {
-          resolve(geojson);
-        } else {
-          console.error('Overpass error:', err);
-          reject(err);
-        }
-      });
+    const postData = querystring.stringify({ data: query });
+
+    return new Promise((resolve, reject) => {
+      const req = https.request(
+        {
+          hostname: 'overpass-api.de',
+          path: '/api/interpreter',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Content-Length': Buffer.byteLength(postData),
+            'User-Agent': 'poibee/1.0',
+            'Accept': '*/*',
+          },
+        },
+        (res) => {
+          if (res.statusCode !== 200) {
+            res.resume();
+            const err = { message: `Request failed: HTTP ${res.statusCode}`, statusCode: res.statusCode };
+            console.error('Overpass error:', err);
+            return reject(err);
+          }
+
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => {
+            try {
+              const parser = new xmldom.DOMParser();
+              const doc = parser.parseFromString(data);
+              resolve(osmtogeojson(doc));
+            } catch (e) {
+              reject(e);
+            }
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.write(postData);
+      req.end();
     });
   }
 }


### PR DESCRIPTION
The Overpass API now rejects requests without a User-Agent header with HTTP 406. Replace query-overpass library with a direct HTTPS call to gain full control over request headers.