### PR TITLE
#17: add User-Agent header to fix Overpass API 406 errors

### DIFF
--- a/src/service/overpass-client.service.ts
+++ b/src/service/overpass-client.service.ts
@@ -1,55 +1,32 @@
 import { FeatureCollection, GeometryObject } from 'geojson';
 import { Injectable } from '@nestjs/common';
-import * as https from 'https';
-import * as querystring from 'querystring';
 
-const osmtogeojson = require('osmtogeojson');
-const xmldom = require('xmldom');
+// Patch request.post to add User-Agent before query-overpass loads it.
+// query-overpass and this file resolve to the same cached `request` module
+// instance, so wrapping .post here also affects query-overpass's internal calls.
+const request = require('request');
+const originalPost = request.post;
+request.post = function (uri, options, callback) {
+  options = options || {};
+  options.headers = Object.assign({ 'User-Agent': 'poibee/1.0' }, options.headers);
+  return originalPost.call(request, uri, options, callback);
+};
+
+const QueryOverpass = require('query-overpass');
 
 @Injectable()
 export class OverpassClientService {
   async query(query: string): Promise<FeatureCollection<GeometryObject>> {
     console.log('Overpass query: ' + query);
-    const postData = querystring.stringify({ data: query });
-
-    return new Promise((resolve, reject) => {
-      const req = https.request(
-        {
-          hostname: 'overpass-api.de',
-          path: '/api/interpreter',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Content-Length': Buffer.byteLength(postData),
-            'User-Agent': 'poibee/1.0',
-            'Accept': '*/*',
-          },
-        },
-        (res) => {
-          if (res.statusCode !== 200) {
-            res.resume();
-            const err = { message: `Request failed: HTTP ${res.statusCode}`, statusCode: res.statusCode };
-            console.error('Overpass error:', err);
-            return reject(err);
-          }
-
-          let data = '';
-          res.on('data', (chunk) => (data += chunk));
-          res.on('end', () => {
-            try {
-              const parser = new xmldom.DOMParser();
-              const doc = parser.parseFromString(data);
-              resolve(osmtogeojson(doc));
-            } catch (e) {
-              reject(e);
-            }
-          });
-        },
-      );
-
-      req.on('error', reject);
-      req.write(postData);
-      req.end();
+    return new Promise<FeatureCollection<GeometryObject>>((resolve, reject) => {
+      QueryOverpass(query, function (err: any, geojson: FeatureCollection<GeometryObject>) {
+        if (!err) {
+          resolve(geojson);
+        } else {
+          console.error('Overpass error:', err);
+          reject(err);
+        }
+      });
     });
   }
 }


### PR DESCRIPTION
Patch request.post before query-overpass loads to inject User-Agent. The Overpass API now rejects requests without this header with HTTP 406.